### PR TITLE
Check that the meta-strings array is not nil befor accessing it in th…

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1027,8 +1027,12 @@ undo_funcs.nodes = function(name, data)
 		})
 		local metat, meta = get_meta_serializable(pos)
 		meta = meta or minetest.get_meta(pos)
-		meta:from_table(minetest.deserialize(metastrings[k]))
-		metastrings[k] = minetest.serialize(metat)
+		if metastrings ~= nil then
+			if metastrings[k] ~= nil then
+				meta:from_table(minetest.deserialize(metastrings[k]))
+			end
+			metastrings[k] = minetest.serialize(metat)
+		end
 	end
 
 	-- update history entry


### PR DESCRIPTION
Hello,
I put below the description of the bug in our fork.

To be honest, I made a small manipulation mistake.
I was not planning to submit this PR directly, as I do not know if I really corrected the cause of the problem.
At least it seems that I corrected the symptom...

Sorry if it seems a little bit abrupt.

regards,

ymh

=========
In some conditions, the undo of a load operation produces a server crash with the following trace in the logs:

```
2020-10-09 11:44:48: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'we_undo' in callback on_chat_message(): /usr/loca
l/share/minetest/games/unej/mods/we_undo/init.lua:1030: attempt to index local 'metastrings' (a nil value)
2020-10-09 11:44:48: ERROR[Main]: stack traceback:
2020-10-09 11:44:48: ERROR[Main]:       /usr/local/share/minetest/games/unej/mods/we_undo/init.lua:1030: in function </usr/local/share/minetest/games/une
j/mods/we_undo/init.lua:967>
2020-10-09 11:44:48: ERROR[Main]:       /usr/local/share/minetest/games/unej/mods/we_undo/init.lua:146: in function 'bare_apply_undo'
2020-10-09 11:44:48: ERROR[Main]:       /usr/local/share/minetest/games/unej/mods/we_undo/init.lua:153: in function 'apply_undo'
2020-10-09 11:44:48: ERROR[Main]:       /usr/local/share/minetest/games/unej/mods/we_undo/init.lua:180: in function 'func'
2020-10-09 11:44:48: ERROR[Main]:       /usr/local/share/minetest/builtin/game/chat.lua:69: in function </usr/local/share/minetest/builtin/game/chat.lua:
48>
2020-10-09 11:44:48: ERROR[Main]:       /usr/local/share/minetest/builtin/game/register.lua:429: in function </usr/local/share/minetest/builtin/game/regi
ster.lua:413>
```

Steps to reproduce the problem:

1. install the following mods or mod packs :

- [abriglass](https://github.com/Ezhh/abriglass)
- [abripanes](https://github.com/Ezhh/abripanes)
- [display_modpack](https://github.com/pyrollo/display_modpack)
- [mesecons](https://github.com/minetest-mods/mesecons)
- [moreblocks](https://github.com/minetest-mods/moreblocks/)
- [signs_lib](https://gitlab.com/VanessaE/signs_lib)
- [travelnet](https://github.com/mt-mods/travelnet)
- [we_undo](https://github.com/HybridDog/we_undo)
- [worldedit](https://github.com/Uberi/Minetest-WorldEdit)

2. put the (uncompressed) attached TEST.we file in a schems folder in the world folder
[TEST.we.zip](https://github.com/IRI-Research/we_undo/files/5372356/TEST.we.zip)

3. run the chat command //1

4. run the chat command //load TEST

5. run the chat command //undo
